### PR TITLE
feat: Security fixes + ReachInbox push + Clay ingest pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -159,6 +159,40 @@ def init_db():
     try:
         conn.execute("ALTER TABLE contacts ADD COLUMN email_verified_at TIMESTAMP")
     except: pass
+
+    # Migration 004: Pipeline foundation columns
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN reachinbox_lead_id TEXT")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN reachinbox_workspace TEXT")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN reachinbox_pushed_at TIMESTAMP")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN reachinbox_campaign_id INTEGER")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN pipeline_stage TEXT DEFAULT 'new'")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE contacts ADD COLUMN enrichment_source TEXT")
+    except: pass
+    try:
+        conn.execute("ALTER TABLE campaigns ADD COLUMN market TEXT DEFAULT 'US'")
+    except: pass
+    try:
+        conn.execute("""CREATE TABLE IF NOT EXISTS reachinbox_push_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contact_id INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+            campaign_id INTEGER REFERENCES campaigns(id),
+            reachinbox_campaign_id INTEGER NOT NULL,
+            workspace TEXT NOT NULL,
+            status TEXT DEFAULT 'pushed',
+            error_message TEXT,
+            pushed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)""")
+    except: pass
     try:
         conn.execute("ALTER TABLE contacts ADD COLUMN email_verification_event TEXT")
     except: pass
@@ -359,12 +393,14 @@ class CampaignCreate(BaseModel):
     description: Optional[str] = None
     country: Optional[str] = None
     status: str = "Active"
+    market: str = "US"  # US or MX - determines ReachInbox workspace
 
 class CampaignUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     country: Optional[str] = None
     status: Optional[str] = None
+    market: Optional[str] = None  # US or MX
     emails_sent: Optional[int] = None
     emails_opened: Optional[int] = None
     emails_clicked: Optional[int] = None
@@ -529,12 +565,15 @@ def change_password(data: ChangePassword, user: dict = Depends(get_current_user)
     return {"message": "Password changed successfully"}
 
 @app.get("/api/users")
-def get_users():
+def get_users(user: dict = Depends(get_current_user)):
+    if not user: raise HTTPException(401, "Not authenticated")
     conn = get_db(); users = conn.execute("SELECT id, email, name, role, is_active, created_at FROM users ORDER BY created_at DESC").fetchall(); conn.close()
     return {"data": [dict(u) for u in users]}
 
 @app.delete("/api/users/{user_id}")
-def delete_user(user_id: int):
+def delete_user(user_id: int, user: dict = Depends(get_current_user)):
+    if not user: raise HTTPException(401, "Not authenticated")
+    if user.get("role") != "admin": raise HTTPException(403, "Admin only")
     conn = get_db(); conn.execute("UPDATE users SET is_active=0 WHERE id=?", (user_id,)); conn.commit(); conn.close()
     return {"message": "Deactivated"}
 
@@ -1975,7 +2014,7 @@ def get_campaign(campaign_id: int):
 @app.post("/api/campaigns")
 def create_campaign(campaign: CampaignCreate):
     conn = get_db()
-    try: conn.execute("INSERT INTO campaigns (name, description, country, status) VALUES (?, ?, ?, ?)", (campaign.name, campaign.description, campaign.country, campaign.status)); cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]; conn.commit(); return {"id": cid, "message": "Created"}
+    try: conn.execute("INSERT INTO campaigns (name, description, country, status, market) VALUES (?, ?, ?, ?, ?)", (campaign.name, campaign.description, campaign.country, campaign.status, campaign.market)); cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]; conn.commit(); return {"id": cid, "message": "Created"}
     except sqlite3.IntegrityError: raise HTTPException(400, "Name exists")
     finally: conn.close()
 
@@ -2315,8 +2354,8 @@ async def reachinbox_webhook(request: Request):
             "contact_matched": email is not None
         }
     except Exception as e:
-        import traceback
-        return {"status": "error", "message": str(e), "traceback": traceback.format_exc()}
+        # Note: traceback intentionally NOT returned to avoid leaking internals
+        return {"status": "error", "message": str(e)}
 
 @app.post("/webhook/bulkemailchecker")
 async def bulkemailchecker_webhook(request: Request):
@@ -2347,6 +2386,99 @@ async def bulkemailchecker_webhook(request: Request):
     conn.execute("INSERT INTO webhook_events (source, event_type, email, payload, processed) VALUES (?, ?, ?, ?, TRUE)", ('bulkemailchecker', 'validation', None, json.dumps(payload)))
     conn.commit(); conn.close()
     return {"status": "ok", "message": f"Processed {stats['processed']} emails", "stats": stats}
+
+# ====================================================================================
+# CLAY INGEST WEBHOOK — Accept contacts directly from Clay workflows
+# ====================================================================================
+
+@app.post("/webhook/clay")
+async def clay_ingest_webhook(request: Request):
+    """
+    Accept contacts from a Clay webhook. POST a JSON payload:
+    {
+        "contacts": [{"email": "...", "first_name": "...", "company": "...", ...}],
+        "outreach_list": "optional-list-name",
+        "campaign": "optional-campaign-name",
+        "country_strategy": "optional"
+    }
+    Contacts are inserted or merged by email.
+    """
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(400, "Invalid JSON payload")
+
+    contacts_data = payload.get("contacts", [])
+    if not contacts_data:
+        return {"status": "ok", "message": "No contacts in payload", "imported": 0, "merged": 0}
+
+    outreach_list_name = payload.get("outreach_list")
+    campaign_name = payload.get("campaign")
+    country_strategy = payload.get("country_strategy")
+    conn = get_db()
+    imported, merged = 0, 0
+    now = datetime.now().isoformat()
+
+    for c in contacts_data:
+        email = (c.get("email") or "").strip().lower()
+        if not email:
+            continue
+
+        existing = conn.execute("SELECT id FROM contacts WHERE LOWER(email)=?", (email,)).fetchone()
+        fields = {
+            "first_name": c.get("first_name") or c.get("firstName"),
+            "last_name": c.get("last_name") or c.get("lastName"),
+            "email": email,
+            "title": c.get("title") or c.get("job_title"),
+            "company": c.get("company") or c.get("company_name"),
+            "person_linkedin_url": c.get("linkedin_url") or c.get("person_linkedin_url"),
+            "domain": c.get("company_domain") or c.get("domain"),
+            "website": c.get("website"),
+            "company_country": c.get("company_country") or c.get("country"),
+            "seniority": c.get("seniority"),
+            "industry": c.get("industry"),
+            "enrichment_source": c.get("enrichment_source", "clay"),
+            "country_strategy": country_strategy,
+            "source_file": "clay_webhook",
+            "updated_at": now,
+        }
+        fields = {k: v for k, v in fields.items() if v is not None}
+
+        if existing:
+            contact_id = existing[0]
+            # Only update fields that exist in incoming data and are non-empty
+            # Use simple assignment (new data wins for fields that were provided)
+            non_email = [k for k in fields if k not in ("email", "source_file", "updated_at")]
+            if non_email:
+                set_clauses = [f"{k}=?" for k in non_email]
+                set_clauses.append("updated_at=?")
+                values = [fields[k] for k in non_email] + [now, contact_id]
+                conn.execute(f"UPDATE contacts SET {','.join(set_clauses)} WHERE id=?", values)
+            merged += 1
+        else:
+            cols = ", ".join(fields.keys())
+            ph = ", ".join(["?"] * len(fields))
+            conn.execute(f"INSERT INTO contacts ({cols}) VALUES ({ph})", list(fields.values()))
+            contact_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            imported += 1
+
+        if outreach_list_name:
+            conn.execute("INSERT OR IGNORE INTO outreach_lists (name) VALUES (?)", (outreach_list_name,))
+            lst = conn.execute("SELECT id FROM outreach_lists WHERE name=?", (outreach_list_name,)).fetchone()
+            if lst:
+                conn.execute("INSERT OR IGNORE INTO contact_lists (contact_id, list_id) VALUES (?, ?)", (contact_id, lst[0]))
+
+        if campaign_name:
+            conn.execute("INSERT OR IGNORE INTO campaigns (name) VALUES (?)", (campaign_name,))
+            camp = conn.execute("SELECT id FROM campaigns WHERE name=?", (campaign_name,)).fetchone()
+            if camp:
+                conn.execute("INSERT OR IGNORE INTO contact_campaigns (contact_id, campaign_id) VALUES (?, ?)", (contact_id, camp[0]))
+
+    conn.commit()
+    conn.close()
+    update_counts()  # Called after close to avoid SQLite "database is locked" on same connection
+    return {"status": "ok", "imported": imported, "merged": merged, "total": imported + merged}
+
 
 @app.post("/webhook/{source}")
 async def generic_webhook(source: str, request: Request):
@@ -3186,6 +3318,172 @@ def get_active_verification_jobs():
 
 
 # ==================== END EMAIL VERIFICATION ====================
+
+# ====================================================================================
+# REACHINBOX OUTBOUND PUSH — Dual Workspace (US + MX)
+# ====================================================================================
+
+REACHINBOX_API_BASE = "https://api.reachinbox.ai/api/v1"
+REACHINBOX_WORKSPACE_KEYS = {
+    "US": "reachinbox_api_key_us",
+    "MX": "reachinbox_api_key_mx",
+}
+
+
+def _get_reachinbox_key(workspace: str, conn) -> Optional[str]:
+    """Fetch ReachInbox API key for a workspace from settings table."""
+    settings_key = REACHINBOX_WORKSPACE_KEYS.get(workspace.upper())
+    if not settings_key:
+        return None
+    row = conn.execute("SELECT value FROM settings WHERE key=?", (settings_key,)).fetchone()
+    return row[0] if row and row[0] else None
+
+
+class ReachInboxPushRequest(BaseModel):
+    contact_ids: List[int]
+    reachinbox_campaign_id: int  # The numeric campaign ID inside ReachInbox
+    workspace: str = "US"        # "US" or "MX"
+    deduply_campaign_id: Optional[int] = None
+    email_status_filter: Optional[List[str]] = None  # e.g. ["Valid"] - skip others
+
+
+@app.post("/api/reachinbox/push")
+async def push_to_reachinbox(req: ReachInboxPushRequest, user: dict = Depends(get_current_user)):
+    """Push contacts into a ReachInbox campaign sequence (US or MX workspace)."""
+    if not user:
+        raise HTTPException(401, "Not authenticated")
+
+    workspace = req.workspace.upper()
+    if workspace not in ("US", "MX"):
+        raise HTTPException(400, "workspace must be US or MX")
+
+    conn = get_db()
+    api_key = _get_reachinbox_key(workspace, conn)
+    if not api_key:
+        conn.close()
+        raise HTTPException(400, f"ReachInbox API key for {workspace} not configured. "
+                                 f"Add reachinbox_api_key_{workspace.lower()} in Settings.")
+
+    allowed_statuses = req.email_status_filter or ["Valid"]
+    placeholders = ",".join(["?"] * len(req.contact_ids))
+    contacts = conn.execute(
+        f"SELECT id, first_name, last_name, email, company, website, person_linkedin_url, "
+        f"email_status, pipeline_stage FROM contacts WHERE id IN ({placeholders})",
+        req.contact_ids
+    ).fetchall()
+
+    stats = {"pushed": 0, "skipped_invalid_email": 0, "skipped_already_pushed": 0, "failed": 0}
+    now = datetime.now().isoformat()
+    batch = []
+
+    for c in contacts:
+        cid, fname, lname, email, company, website, linkedin, email_status, pipeline =             c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7] or "Unknown", c[8] or "new"
+
+        if email_status not in allowed_statuses:
+            conn.execute(
+                "INSERT INTO reachinbox_push_log (contact_id, campaign_id, reachinbox_campaign_id, workspace, status, error_message) "
+                "VALUES (?, ?, ?, ?, 'skipped', ?)",
+                (cid, req.deduply_campaign_id, req.reachinbox_campaign_id, workspace,
+                 f"email_status={email_status} not in {allowed_statuses}")
+            )
+            stats["skipped_invalid_email"] += 1
+            continue
+
+        already = conn.execute(
+            "SELECT id FROM reachinbox_push_log WHERE contact_id=? AND reachinbox_campaign_id=? AND status='pushed'",
+            (cid, req.reachinbox_campaign_id)
+        ).fetchone()
+        if already:
+            stats["skipped_already_pushed"] += 1
+            continue
+
+        batch.append({"_db_id": cid, "email": email, "firstName": fname or "",
+                      "lastName": lname or "", "companyName": company or "",
+                      "website": website or "", "linkedinUrl": linkedin or ""})
+
+    BATCH_SIZE = 50
+    for i in range(0, len(batch), BATCH_SIZE):
+        chunk = batch[i:i + BATCH_SIZE]
+        leads_payload = [{k: v for k, v in lead.items() if k != "_db_id"} for lead in chunk]
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(
+                    f"{REACHINBOX_API_BASE}/leads",
+                    headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                    json={"campaignId": req.reachinbox_campaign_id, "leads": leads_payload}
+                )
+            resp_ok = resp.status_code in (200, 201)
+            error_msg = None if resp_ok else (resp.json().get("message", f"HTTP {resp.status_code}") if resp.content else f"HTTP {resp.status_code}")
+
+            for lead in chunk:
+                db_id = lead["_db_id"]
+                if resp_ok:
+                    conn.execute(
+                        "UPDATE contacts SET reachinbox_workspace=?, reachinbox_campaign_id=?, "
+                        "reachinbox_pushed_at=?, pipeline_stage='pushed', updated_at=? WHERE id=?",
+                        (workspace, req.reachinbox_campaign_id, now, now, db_id)
+                    )
+                    conn.execute(
+                        "INSERT INTO reachinbox_push_log (contact_id, campaign_id, reachinbox_campaign_id, workspace, status) "
+                        "VALUES (?, ?, ?, ?, 'pushed')",
+                        (db_id, req.deduply_campaign_id, req.reachinbox_campaign_id, workspace)
+                    )
+                    stats["pushed"] += 1
+                else:
+                    conn.execute(
+                        "INSERT INTO reachinbox_push_log (contact_id, campaign_id, reachinbox_campaign_id, workspace, status, error_message) "
+                        "VALUES (?, ?, ?, ?, 'failed', ?)",
+                        (db_id, req.deduply_campaign_id, req.reachinbox_campaign_id, workspace, error_msg)
+                    )
+                    stats["failed"] += 1
+        except Exception as e:
+            for lead in chunk:
+                conn.execute(
+                    "INSERT INTO reachinbox_push_log (contact_id, campaign_id, reachinbox_campaign_id, workspace, status, error_message) "
+                    "VALUES (?, ?, ?, ?, 'failed', ?)",
+                    (lead["_db_id"], req.deduply_campaign_id, req.reachinbox_campaign_id, workspace, str(e))
+                )
+            stats["failed"] += len(chunk)
+
+    conn.commit()
+    conn.close()
+    return {"status": "ok", "workspace": workspace,
+            "reachinbox_campaign_id": req.reachinbox_campaign_id, "stats": stats}
+
+
+@app.get("/api/reachinbox/push-log")
+def get_push_log(contact_id: Optional[int] = None, campaign_id: Optional[int] = None,
+                 limit: int = 100, user: dict = Depends(get_current_user)):
+    """Get ReachInbox push history."""
+    if not user:
+        raise HTTPException(401, "Not authenticated")
+    conn = get_db()
+    where, params = ["1=1"], []
+    if contact_id:
+        where.append("contact_id=?"); params.append(contact_id)
+    if campaign_id:
+        where.append("campaign_id=?"); params.append(campaign_id)
+    rows = conn.execute(
+        f"SELECT * FROM reachinbox_push_log WHERE {' AND '.join(where)} ORDER BY pushed_at DESC LIMIT ?",
+        params + [limit]
+    ).fetchall()
+    conn.close()
+    return {"data": [dict(r) for r in rows]}
+
+
+@app.get("/api/reachinbox/workspace-status")
+def get_workspace_status(user: dict = Depends(get_current_user)):
+    """Check which ReachInbox workspaces are configured."""
+    if not user:
+        raise HTTPException(401, "Not authenticated")
+    conn = get_db()
+    result = {}
+    for workspace, key_name in REACHINBOX_WORKSPACE_KEYS.items():
+        row = conn.execute("SELECT value FROM settings WHERE key=?", (key_name,)).fetchone()
+        result[workspace] = {"configured": bool(row and row[0]), "settings_key": key_name}
+    conn.close()
+    return result
+
 
 @app.get("/health")
 def health():

--- a/backend/migrations/004_pipeline_foundation.sql
+++ b/backend/migrations/004_pipeline_foundation.sql
@@ -1,0 +1,37 @@
+-- Migration 004: Pipeline Foundation
+-- Adds market field to campaigns for US/MX workspace routing
+-- Adds ReachInbox push tracking fields to contacts
+-- Run in Supabase SQL Editor
+
+-- 1. Add market field to campaigns (US or MX workspace routing)
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS market TEXT DEFAULT 'US';
+
+-- 2. Add ReachInbox push tracking to contacts
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS reachinbox_lead_id TEXT;
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS reachinbox_workspace TEXT;
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS reachinbox_pushed_at TIMESTAMP;
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS reachinbox_campaign_id INTEGER;
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS pipeline_stage TEXT DEFAULT 'new';
+-- pipeline_stage values: new | validated | queued | pushed | active | finished
+
+-- 3. Add enrichment tracking (for future BlitzAPI / Clay webhook integration)
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS enrichment_source TEXT;
+
+-- 4. Create push_log table to track what was pushed where and when
+CREATE TABLE IF NOT EXISTS reachinbox_push_log (
+    id SERIAL PRIMARY KEY,
+    contact_id INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    campaign_id INTEGER REFERENCES campaigns(id),
+    reachinbox_campaign_id INTEGER NOT NULL,
+    workspace TEXT NOT NULL,
+    status TEXT DEFAULT 'pushed',
+    error_message TEXT,
+    pushed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_log_contact ON reachinbox_push_log(contact_id);
+CREATE INDEX IF NOT EXISTS idx_push_log_campaign ON reachinbox_push_log(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_contacts_pipeline_stage ON contacts(pipeline_stage);
+CREATE INDEX IF NOT EXISTS idx_contacts_reachinbox_workspace ON contacts(reachinbox_workspace);
+
+SELECT 'migration 004 complete' as status;


### PR DESCRIPTION
## What this PR does

### 🔒 Security Fixes
- **Auth added** to `GET /api/users` and `DELETE /api/users/{id}` — these were completely unauthenticated (any request could list or deactivate users)
- **Admin guard** on user deletion — only admin-role users can deactivate accounts
- **Traceback removed** from webhook error responses — production was leaking internal stack traces in HTTP responses

### 🚀 ReachInbox Outbound Push (the #1 blocker per Hermes)
New endpoint: `POST /api/reachinbox/push`
- Pushes contacts to a ReachInbox campaign sequence
- **Dual workspace support** (US or MX) — workspace determined by `workspace` param
- Batches of 50 per API call
- **Idempotent** — won't re-push the same contact to the same campaign
- **Email validation gate** — by default only pushes contacts with `email_status='Valid'`, configurable via `email_status_filter`
- Full push log in `reachinbox_push_log` table for audit trail
- Proper 400 error if workspace API key not configured

Supporting endpoints:
- `GET /api/reachinbox/workspace-status` — check which workspaces have API keys configured
- `GET /api/reachinbox/push-log` — audit trail, filterable by contact or campaign

### 🏷️ Campaign Market Field
- Added `market` field (US/MX) to campaigns — determines which ReachInbox workspace contacts go to
- Works with existing campaign CRUD (create/update)

### 🔌 Clay Ingest Webhook
New endpoint: `POST /webhook/clay`
- Accepts contact batches directly from Clay workflows (no more manual CSV exports)
- **Deduplicates by email** — inserts new contacts, updates existing ones
- Auto-assigns to outreach list and campaign if provided in payload
- Sets `enrichment_source` field (defaults to 'clay')
- Tested and working

### 🗄️ Schema — Migration 004
**File:** `backend/migrations/004_pipeline_foundation.sql`

New columns on `contacts`:
- `reachinbox_workspace` — which workspace the contact was pushed to
- `reachinbox_campaign_id` — ReachInbox campaign ID
- `reachinbox_pushed_at` — timestamp of push
- `reachinbox_lead_id` — reserved for future ReachInbox lead ID storage
- `pipeline_stage` — new | validated | queued | pushed | active | finished
- `enrichment_source` — manual_import | clay_webhook | blitzapi | apollo

New column on `campaigns`:
- `market` (US/MX)

New table:
- `reachinbox_push_log` — full audit trail of every push attempt

**SQLite (local dev):** Columns added automatically via `try/except ALTER TABLE` in `init_db()`
**Supabase (production):** Run `backend/migrations/004_pipeline_foundation.sql` in SQL Editor

## Notes for Rodrigo / Hermes

1. **ReachInbox API keys need to be configured** in Deduply Settings after this merges:
   - Key: `reachinbox_api_key_us` → US workspace key
   - Key: `reachinbox_api_key_mx` → MX workspace key

2. **Two of Hermes's pain points already exist** in the codebase:
   - `contacts.email_status` field already exists and is populated
   - `/webhook/bulkemailchecker` already exists and is live — Hermes can point BulkEmailChecker webhooks to it now without waiting

3. **Do NOT merge to main yourself** — Rodrigo reviews and merges.

## Testing
- Clay webhook: POSTed test contact, verified insertion + list/campaign assignment ✅
- ReachInbox push: Verified 400 when no API key configured ✅
- Auth: Verified 401 on `/api/users` without token ✅
- Syntax: `ast.parse(main.py)` clean ✅